### PR TITLE
Fix wiring & add CORS support

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,17 +4,37 @@ const connectDB = require("./db/db");
 const path = require("node:path");
 const provision = require("./provision/user.provision");
 const fs = require("fs");
+// Simple CORS middleware
+const corsMiddleware = (req, res, next) => {
+  const origin = process.env.CORS_ORIGIN || "*";
+  res.header("Access-Control-Allow-Origin", origin);
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+  );
+  res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(200);
+  }
+  next();
+};
 
 provision.provision();
 
 connectDB();
 
 app.use(express.json());
+app.use(corsMiddleware);
 
 const uploadRoot = path.join(__dirname, "uploads");
 if (!fs.existsSync(uploadRoot)) fs.mkdirSync(uploadRoot, { recursive: true });
+app.use("/uploads", express.static(uploadRoot));
 
-app.use("/uploads", express.static(path.join(__dirname, "uploads")));
+// Health check endpoint
+app.get("/api/health", (req, res) => {
+  res.json({ ok: true });
+});
+
 app.use("/api/chats", require("./routes/chat.routes"));
 app.use("/api/users", require("./routes/user.routes"));
 
@@ -23,7 +43,7 @@ const vueDistPath = path.join(__dirname, "../client/dist");
 app.use(express.static(vueDistPath));
 
 // Catch-all SPA route
-app.get("/{*any}", (req, res) => {
+app.use((req, res) => {
   res.sendFile(path.join(vueDistPath, "index.html"));
 });
 


### PR DESCRIPTION
## Summary
- add /api/health endpoint
- add simple env-driven CORS middleware
- adjust SPA fallback ordering

## Testing
- `npm run dev` *(fails: querySrv ENOTFOUND _mongodb._tcp.twinder.faafv0x.mongodb.net)*

------
https://chatgpt.com/codex/tasks/task_e_68a5956a39dc8322a40906346b269a2f